### PR TITLE
Display full hash in table

### DIFF
--- a/lib/cli/util/table.js
+++ b/lib/cli/util/table.js
@@ -7,7 +7,7 @@ function logBlockchain(blockchain) {
     const table = new Table({
       style:{border:[],header:[]},
       wordWrap: true,
-      colWidths:[20,20]
+      colWidths:[20,66]
     });
     const object = JSON.parse(JSON.stringify(block))
     for(let key in object) {


### PR DESCRIPTION
Because of the table column width, the hash was getting cut off which
hid some information that could be useful for someone experiementing
with this tool. By bumping the width of the value field up to 66. It
will display the full hash.

Before: 0000f96fdd0178807…
After: 00004556469a14cbbb0f6383a6bfd7c61aa6c0a8c78d4b9a08a8478bc060a73e

Closes #13