### PR TITLE
Round the timestamp value down

### DIFF
--- a/lib/blockchain/index.js
+++ b/lib/blockchain/index.js
@@ -104,7 +104,7 @@ class Blockchain {
   generateNextBlock (blockData) {
     const previousBlock = this.latestBlock;
     const nextIndex = previousBlock.index + 1;
-    const nextTimestamp = new Date().getTime() / 1000
+    const nextTimestamp = Math.floor(new Date().getTime() / 1000);
     let nonce = 0;
     let nextHash = '';
     const randSpinner = spinner.getRandomSpinner();


### PR DESCRIPTION
Since in JavaScript timestamps are done in MS, this dividing by 1000
produces a number with a decimal. By flooring it, we produce
a consistent number that matches how other langauges generate
timestamps.

I encountered this issue when creating my own blockchain implementation in Ruby, and noticing the hash didn't match when I put in the same inputs. It turned out that since this was using decimals for the timestamp it didn't match. This resolves it.

Also, there are many tests failing on master right now, so I was unable to write one for this or make sure this didn't break more.