### PR TITLE
allow arguments passing from cli without having the app running

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -11,4 +11,5 @@ module.exports = function (vorpal) {
     .use(require('./util/welcome.js'))
     .delimiter('blockchain →')
     .show()
+    .parse(process.argv)
 }


### PR DESCRIPTION
allows cli execution without the need to have the app running, for example :
`$blockchain-cli blockchain` which will invoke displaying of the chain without the need to have the app stayed running

